### PR TITLE
Update properties file to point to maven 3.2.3

### DIFF
--- a/maven/wrapper/maven-wrapper.properties
+++ b/maven/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repository.apache.org/content/repositories/releases/org/apache/maven/apache-maven/3.0.5/apache-maven-3.0.5-bin.zip
+distributionUrl=https://repository.apache.org/content/repositories/releases/org/apache/maven/apache-maven/3.2.3/apache-maven-3.2.3-bin.zip


### PR DESCRIPTION
The properties file was pointing to 3.0.5 of maven, and the
latest version is now 3.2.3.  This commit updates to make sure
maven 3.2.3 is downloaded if if doesn't already exist.
